### PR TITLE
Change to pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This is code to run the Gait Transformer described in:
 
 ## Installation
 
-    pip install -r requirements.txt
     pip install -e .
+
+For further information, refer [here](https://gist.github.com/peifferjd/0afc6484a99cf968cde16edb26752901).
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,33 +1,25 @@
-[tool.black]
-line-length = 150
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
-
-[tool.poetry]
+[project]
 name = "gait_transformer"
 version = "0.0.1"
 description = "Gait Transformer"
-authors = ["James Cotton <peabody124@gmail.com>"]
-license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/peabody124/GaitTransformer"
-keywords = ["gait", "transformer", "biomechanics"]
-classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
+requires-python = "~=3.11"
+dependencies = [
+    "tensorflow>=2.18.0",
+    "keras>=3.7.0",
+    "jaxlib",
+    "jax",
+    "matplotlib",
+    "numpy",
 ]
-python = ">=3.10"
 
-[tool.poetry.dependencies]
-tensorflow = "*"
-jax = "*"
-numpy = "*"
 
-[tool.poetry.urls]
-homepage = "https://github.com/peabody124/GaitTransformer"
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.poetry.package.include]
-gait_transformer = ["assets/model_v0.2.h5"]
+[tool.uv]
+find-links = ["https://storage.googleapis.com/jax-releases/jax_cuda_releases.html"]
+
+[tool.black]
+line-length = 150

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-tensorflow
-jaxlib
-jax
-matplotlib
-numpy


### PR DESCRIPTION
Can now build package with pyproject. This should be a transparent change as `pip install -e .` should still work with conda or pip. However, the pyproject now details tools for [uv](https://docs.astral.sh/uv/), an efficient package manager.