### PR TITLE
Deps, video reader, overlay trace window, and filename dt utility

### DIFF
--- a/gait_transformer/gait_phase_kalman.py
+++ b/gait_transformer/gait_phase_kalman.py
@@ -89,7 +89,7 @@ def gait_kalman_smoother(phases, dt=1.0 / 30.0, smoothing=True):
         return jnp.array([x[0], relu(x[1]), *x[2:]])
 
     @jit
-    def forward_update(carry, phase, dt=1.0 / 30.0):
+    def forward_update(carry, phase, dt=dt):
         x, P = carry
         x, P = predict(x, P, dt)  # , Q=Q)
         x = constrain(x)

--- a/gait_transformer/util.py
+++ b/gait_transformer/util.py
@@ -1,6 +1,6 @@
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 
 import cv2
 import numpy as np
@@ -82,9 +82,10 @@ def video_reader(filename: str, batch_size: int = 8, width: int | None = None):
 
                 frames = []
                 
-def get_dt_from_filename(filename: str) -> datetime | None:
+def get_dt_from_filename(filename: str) -> float | None:
     """
-    Attempt to extract a datetime object from a video filename.
+    Attempt to extract a timestamp from a video filename, returned as a float
+    (seconds since the Unix epoch) so that callers can compute time deltas directly.
     Supports common formats like 'VID_20231027_153022.mp4'.
     Falls back to file modification time if no date is found in the name.
     """
@@ -94,7 +95,8 @@ def get_dt_from_filename(filename: str) -> datetime | None:
     match = re.search(r'(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})', basename)
     if match:
         try:
-            return datetime.strptime(match.group(), "%Y%m%d_%H%M%S")
+            dt = datetime.strptime(match.group(), "%Y%m%d_%H%M%S")
+            return dt.replace(tzinfo=timezone.utc).timestamp()
         except ValueError:
             pass
             
@@ -104,14 +106,14 @@ def get_dt_from_filename(filename: str) -> datetime | None:
         # Reconstruct to standard format for easy parsing
         dt_str = "".join(match.groups())
         try:
-            return datetime.strptime(dt_str, "%Y%m%d%H%M%S")
+            dt = datetime.strptime(dt_str, "%Y%m%d%H%M%S")
+            return dt.replace(tzinfo=timezone.utc).timestamp()
         except ValueError:
             pass
 
     # Fallback to filesystem metadata
     if os.path.exists(filename):
         # Modification time is usually the most reliable fallback for "when it was taken"
-        timestamp = os.path.getmtime(filename) 
-        return datetime.fromtimestamp(timestamp)
+        return os.path.getmtime(filename)
         
     return None

--- a/gait_transformer/util.py
+++ b/gait_transformer/util.py
@@ -2,6 +2,10 @@ import cv2
 import numpy as np
 from tqdm import tqdm
 
+import cv2
+import numpy as np
+from tqdm import tqdm
+
 
 def video_reader(filename: str, batch_size: int = 8, width: int | None = None):
     """
@@ -22,6 +26,22 @@ def video_reader(filename: str, batch_size: int = 8, width: int | None = None):
 
     cap = cv2.VideoCapture(filename)
 
+    # 1. Disable OpenCV's auto-rotation (can be buggy and cause double-rotations)
+    # The flag CAP_PROP_ORIENTATION_AUTO has value 49.
+    auto_prop = getattr(cv2, 'CAP_PROP_ORIENTATION_AUTO', 49)
+    try:
+        cap.set(auto_prop, 0)
+    except Exception:
+        pass  # Fails gracefully on older OpenCV versions
+        
+    # 2. Get the actual rotation metadata
+    # The flag CAP_PROP_ORIENTATION_META has value 48.
+    meta_prop = getattr(cv2, 'CAP_PROP_ORIENTATION_META', 48)
+    try:
+        orientation = int(cap.get(meta_prop))
+    except Exception:
+        orientation = 0
+
     frames = []
     while True:
 
@@ -39,8 +59,17 @@ def video_reader(filename: str, batch_size: int = 8, width: int | None = None):
         else:
             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
 
+            # Apply rotation based on the extracted metadata
+            if orientation == 90:
+                frame = cv2.rotate(frame, cv2.ROTATE_90_CLOCKWISE)
+            elif orientation == 180:
+                frame = cv2.rotate(frame, cv2.ROTATE_180)
+            elif orientation == 270:
+                frame = cv2.rotate(frame, cv2.ROTATE_90_COUNTERCLOCKWISE)
+
             if width is not None:
                 # downsample to keep the aspect ratio and output the specified width
+                # frame.shape[1] and [0] accurately reflect the dimensions *after* rotation
                 scale = width / frame.shape[1]
                 height = int(frame.shape[0] * scale)
                 frame = cv2.resize(frame, (width, height))
@@ -52,3 +81,4 @@ def video_reader(filename: str, batch_size: int = 8, width: int | None = None):
                 yield frames
 
                 frames = []
+                

--- a/gait_transformer/util.py
+++ b/gait_transformer/util.py
@@ -82,38 +82,36 @@ def video_reader(filename: str, batch_size: int = 8, width: int | None = None):
 
                 frames = []
                 
-def get_dt_from_filename(filename: str) -> float | None:
+def get_dt_from_filename(filename: str) -> float:
     """
-    Attempt to extract a timestamp from a video filename, returned as a float
+    Extract a timestamp from a video filename, returned as a float
     (seconds since the Unix epoch) so that callers can compute time deltas directly.
     Supports common formats like 'VID_20231027_153022.mp4'.
     Falls back to file modification time if no date is found in the name.
+
+    Raises:
+        ValueError: If no date pattern is found in the filename and the file does not exist.
     """
     basename = os.path.basename(filename)
-    
+
     # Look for YYYYMMDD_HHMMSS pattern (common in Android/some cameras)
     match = re.search(r'(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})', basename)
     if match:
-        try:
-            dt = datetime.strptime(match.group(), "%Y%m%d_%H%M%S")
-            return dt.replace(tzinfo=timezone.utc).timestamp()
-        except ValueError:
-            pass
-            
+        dt = datetime.strptime(match.group(), "%Y%m%d_%H%M%S")
+        return dt.replace(tzinfo=timezone.utc).timestamp()
+
     # Look for YYYY-MM-DD_HH-MM-SS or similar patterns
     match = re.search(r'(\d{4})-(\d{2})-(\d{2})[_-](\d{2})[-:](\d{2})[-:](\d{2})', basename)
     if match:
-        # Reconstruct to standard format for easy parsing
         dt_str = "".join(match.groups())
-        try:
-            dt = datetime.strptime(dt_str, "%Y%m%d%H%M%S")
-            return dt.replace(tzinfo=timezone.utc).timestamp()
-        except ValueError:
-            pass
+        dt = datetime.strptime(dt_str, "%Y%m%d%H%M%S")
+        return dt.replace(tzinfo=timezone.utc).timestamp()
 
     # Fallback to filesystem metadata
     if os.path.exists(filename):
-        # Modification time is usually the most reliable fallback for "when it was taken"
         return os.path.getmtime(filename)
-        
-    return None
+
+    raise ValueError(
+        f"Could not extract a timestamp from filename {filename!r}: "
+        "no recognised date pattern found and file does not exist."
+    )

--- a/gait_transformer/util.py
+++ b/gait_transformer/util.py
@@ -82,3 +82,36 @@ def video_reader(filename: str, batch_size: int = 8, width: int | None = None):
 
                 frames = []
                 
+def get_dt_from_filename(filename: str) -> datetime | None:
+    """
+    Attempt to extract a datetime object from a video filename.
+    Supports common formats like 'VID_20231027_153022.mp4'.
+    Falls back to file modification time if no date is found in the name.
+    """
+    basename = os.path.basename(filename)
+    
+    # Look for YYYYMMDD_HHMMSS pattern (common in Android/some cameras)
+    match = re.search(r'(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})', basename)
+    if match:
+        try:
+            return datetime.strptime(match.group(), "%Y%m%d_%H%M%S")
+        except ValueError:
+            pass
+            
+    # Look for YYYY-MM-DD_HH-MM-SS or similar patterns
+    match = re.search(r'(\d{4})-(\d{2})-(\d{2})[_-](\d{2})[-:](\d{2})[-:](\d{2})', basename)
+    if match:
+        # Reconstruct to standard format for easy parsing
+        dt_str = "".join(match.groups())
+        try:
+            return datetime.strptime(dt_str, "%Y%m%d%H%M%S")
+        except ValueError:
+            pass
+
+    # Fallback to filesystem metadata
+    if os.path.exists(filename):
+        # Modification time is usually the most reliable fallback for "when it was taken"
+        timestamp = os.path.getmtime(filename) 
+        return datetime.fromtimestamp(timestamp)
+        
+    return None

--- a/gait_transformer/util.py
+++ b/gait_transformer/util.py
@@ -1,7 +1,3 @@
-import os
-import re
-from datetime import datetime, timezone
-
 import cv2
 import numpy as np
 from tqdm import tqdm
@@ -84,34 +80,22 @@ def video_reader(filename: str, batch_size: int = 8, width: int | None = None):
                 
 def get_dt_from_filename(filename: str) -> float:
     """
-    Extract a timestamp from a video filename, returned as a float
-    (seconds since the Unix epoch) so that callers can compute time deltas directly.
-    Supports common formats like 'VID_20231027_153022.mp4'.
-    Falls back to file modification time if no date is found in the name.
+    Return the frame time step dt (in seconds) for a video file, i.e. 1/fps.
+
+    Args:
+        filename: path to the video file.
+
+    Returns:
+        dt as a float in seconds (e.g. ~0.0333 for a 30 Hz video).
 
     Raises:
-        ValueError: If no date pattern is found in the filename and the file does not exist.
+        ValueError: If the file cannot be opened or its frame rate cannot be read.
     """
-    basename = os.path.basename(filename)
-
-    # Look for YYYYMMDD_HHMMSS pattern (common in Android/some cameras)
-    match = re.search(r'(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})', basename)
-    if match:
-        dt = datetime.strptime(match.group(), "%Y%m%d_%H%M%S")
-        return dt.replace(tzinfo=timezone.utc).timestamp()
-
-    # Look for YYYY-MM-DD_HH-MM-SS or similar patterns
-    match = re.search(r'(\d{4})-(\d{2})-(\d{2})[_-](\d{2})[-:](\d{2})[-:](\d{2})', basename)
-    if match:
-        dt_str = "".join(match.groups())
-        dt = datetime.strptime(dt_str, "%Y%m%d%H%M%S")
-        return dt.replace(tzinfo=timezone.utc).timestamp()
-
-    # Fallback to filesystem metadata
-    if os.path.exists(filename):
-        return os.path.getmtime(filename)
-
-    raise ValueError(
-        f"Could not extract a timestamp from filename {filename!r}: "
-        "no recognised date pattern found and file does not exist."
-    )
+    cap = cv2.VideoCapture(filename)
+    if not cap.isOpened():
+        raise ValueError(f"Could not open video file {filename!r}.")
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    cap.release()
+    if fps <= 0:
+        raise ValueError(f"Could not read a valid frame rate from {filename!r} (got {fps}).")
+    return 1.0 / fps

--- a/gait_transformer/util.py
+++ b/gait_transformer/util.py
@@ -1,11 +1,10 @@
-import cv2
-import numpy as np
-from tqdm import tqdm
+import os
+import re
+from datetime import datetime
 
 import cv2
 import numpy as np
 from tqdm import tqdm
-from datetime import datetime
 
 
 def video_reader(filename: str, batch_size: int = 8, width: int | None = None):

--- a/gait_transformer/util.py
+++ b/gait_transformer/util.py
@@ -5,6 +5,7 @@ from tqdm import tqdm
 import cv2
 import numpy as np
 from tqdm import tqdm
+from datetime import datetime
 
 
 def video_reader(filename: str, batch_size: int = 8, width: int | None = None):

--- a/gait_transformer/visualization.py
+++ b/gait_transformer/visualization.py
@@ -105,7 +105,7 @@ def draw_keypoints(
     return image
 
 
-def get_trace_overlay_fn(phases, stride, walking_prob=None):
+def get_trace_overlay_fn(phases, stride, walking_prob=None, trace_window=50):
 
     phases = np.reshape(phases, [-1, 4, 2])[:, :, 0]
     # phases = np.arctan2(phases[:, :, 1], phases[:, :, 0])
@@ -132,10 +132,10 @@ def get_trace_overlay_fn(phases, stride, walking_prob=None):
         def scale_x(x):
             return int(x * (width / 1080))
 
-        if idx > 50 and idx < len(phases) - 50:
-            x = np.linspace(scale_x(750), scale_x(1050), 100)
+        if idx > trace_window and idx < len(phases) - trace_window:
+            x = np.linspace(scale_x(750), scale_x(1050), trace_window * 2)
 
-            idx_range = np.array(range(idx - 50, idx + 50))
+            idx_range = np.array(range(idx - trace_window, idx + trace_window))
 
             # foot pos
             y = scale_y(100, 1300) - stride[idx_range, 0] * scale_y(100, 1300)
@@ -204,7 +204,7 @@ def get_trace_overlay_fn(phases, stride, walking_prob=None):
     return plot_traces
 
 
-def make_overlay(video: str, phases: np.array, stride: np.array, keypoints: np.array, outname=None):
+def make_overlay(video: str, phases: np.array, stride: np.array, keypoints: np.array, outname=None, trace_window=50):
     """
     Make a gait transformer overlay video
 
@@ -214,12 +214,13 @@ def make_overlay(video: str, phases: np.array, stride: np.array, keypoints: np.a
         stride: stride features
         keypoints: keypoints (time x 17 x 3)
         outname: output file name (optional, otherwise returns temp file)
+        trace_window: number of frames on each side of the current frame to show in the trace (default 50)
     """
 
     import tempfile
     import os
 
-    plot_traces = get_trace_overlay_fn(phases, stride)
+    plot_traces = get_trace_overlay_fn(phases, stride, trace_window=trace_window)
 
     phases = np.reshape(phases, [-1, 4, 2])
     phases = np.arctan2(phases[:, :, 1], phases[:, :, 0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "gait_transformer"
 version = "0.0.1"
 description = "Gait Transformer"
 readme = "README.md"
-requires-python = "~=3.11"
 dependencies = [
     "tensorflow>=2.18.0",
     "keras>=3.7.0",


### PR DESCRIPTION
Few fixes across packaging/runtime behavior and visualization:

- updates dependency metadata
- updates video reader orientation handling
- fixes Kalman smoother `dt` default propagation
- makes the overlay trace edge filter configurable by replacing the hardcoded `50` with a default `trace_window=50` parameter and routing it through `make_overlay`, so callers can override it
- adds `get_dt_from_filename` which reads the frame rate from a video file via OpenCV and returns `1.0 / fps` as a `float` (e.g. ~0.0333 for 30 Hz), raising `ValueError` if the file cannot be opened or has no valid FPS — suitable for passing directly to the Kalman smoother's `dt` parameter